### PR TITLE
Fix cross-page references.

### DIFF
--- a/docs/API Full REST API/creating store items on the web.md
+++ b/docs/API Full REST API/creating store items on the web.md
@@ -1,1 +1,1 @@
-See [Generic: Creating store items on the web](../generic/creating_store_items_on_the_web.md).
+See <a href="/generic/creating_store_items_on_the_web/">Generic: Creating store items on the web</a>.

--- a/docs/API Full REST API/forgot password.md
+++ b/docs/API Full REST API/forgot password.md
@@ -78,4 +78,4 @@ None
 
 ### User Experience
 
-See [Generic: Forgot password - User experience](../generic/forgot_password.md/#user-experience).
+See <a href="/generic/forgot_password/#user-experience">Generic: Forgot password - User experience</a>.

--- a/docs/Blueprints Unreal/creating store items on the web.md
+++ b/docs/Blueprints Unreal/creating store items on the web.md
@@ -1,1 +1,1 @@
-See [Generic: Creating store items on the web](../generic/creating_store_items_on_the_web.md).
+See <a href="/generic/creating_store_items_on_the_web/">Generic: Creating store items on the web</a>.

--- a/docs/Blueprints Unreal/forgot password.md
+++ b/docs/Blueprints Unreal/forgot password.md
@@ -15,4 +15,4 @@ they can login into your app.
 
 ## User Experience
 
-See [Generic: Forgot password - User experience](../generic/forgot_password.md/#user-experience).
+See <a href="/generic/forgot_password/#user-experience">Generic: Forgot password - User experience</a>.

--- a/docs/C# Unity 3D/creating store items on the web.md
+++ b/docs/C# Unity 3D/creating store items on the web.md
@@ -1,1 +1,1 @@
-See [Generic: Creating store items on the web](../generic/creating_store_items_on_the_web.md).
+See <a href="/generic/creating_store_items_on_the_web/">Generic: Creating store items on the web</a>.

--- a/docs/C++ Unreal Engine/creating store items on the web.md
+++ b/docs/C++ Unreal Engine/creating store items on the web.md
@@ -1,1 +1,1 @@
-See [Generic: Creating store items on the web](../generic/creating_store_items_on_the_web.md).
+See <a href="/generic/creating_store_items_on_the_web/">Generic: Creating store items on the web</a>.

--- a/docs/C++ Unreal Engine/forgot password.md
+++ b/docs/C++ Unreal Engine/forgot password.md
@@ -49,4 +49,4 @@ they can login into your app.
 
 ## User Experience
 
-See [Generic: Forgot password - User experience](../generic/forgot_password.md/#user-experience).
+See <a href="/generic/forgot_password/#user-experience">Generic: Forgot password - User experience</a>.

--- a/docs/JS Playcanvas, PixiJS, BabylonJS/creating store items on the web.md
+++ b/docs/JS Playcanvas, PixiJS, BabylonJS/creating store items on the web.md
@@ -1,1 +1,1 @@
-See [Generic: Creating store items on the web](../generic/creating_store_items_on_the_web.md).
+See <a href="/generic/creating_store_items_on_the_web/">Generic: Creating store items on the web</a>.

--- a/docs/JS Playcanvas, PixiJS, BabylonJS/forgot password.md
+++ b/docs/JS Playcanvas, PixiJS, BabylonJS/forgot password.md
@@ -42,4 +42,4 @@ they can login into your app.
 
 ## User Experience
 
-See [Generic: Forgot password - User experience](../generic/forgot_password.md/#user-experience).
+See <a href="/generic/forgot_password/#user-experience">Generic: Forgot password - User experience</a>.


### PR DESCRIPTION
Using `a href` tags should fix the links in all deployments