### PR TITLE
Fix/cpp typos

### DIFF
--- a/docs/C++ Unreal Engine/class methods.md
+++ b/docs/C++ Unreal Engine/class methods.md
@@ -23,7 +23,7 @@ UGameFuseManager::FetchStoreItems(FManagerCallback CompletionCallback);
 ## User functions
 
 ```cpp
-UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 
 GameFuseUser->GetNumberOfLogins();
 GameFuseUser->GetLastLogin();

--- a/docs/C++ Unreal Engine/class methods.md
+++ b/docs/C++ Unreal Engine/class methods.md
@@ -5,19 +5,19 @@ Check each model below for a list of methods and attributes.
 ## GameFuse static functions
 
 ```cpp
-UGameFuseManager::SetUpGame(const FString& InGameId, const FString& InToken, bool bSeedStore, FManagerCallback CompletionCallback);
-UGameFuseManager::GetGameId();
-UGameFuseManager::GetGameName();
-UGameFuseManager::GetGameDescription();
-UGameFuseManager::GetGameToken();
-UGameFuseManager::GetBaseURL();
-UGameFuseManager::GetGameVariables();
-UGameFuseManager::GetGameStoreItems();
-UGameFuseManager::GetLeaderboard();
-UGameFuseManager::(const FString& Email, FManagerCallback CompletionCallback);
-UGameFuseManager::FetchGameVariables(FManagerCallback CompletionCallback);
-UGameFuseManager::FetchLeaderboardEntries(UGameFuseUser* GameFuseUser, const int Limit, bool bOnePerUser, const FString& LeaderboardName, FManagerCallback CompletionCallback);
-UGameFuseManager::FetchStoreItems(FManagerCallback CompletionCallback);
+UGameFuseCore::SetUpGame(const FString& InGameId, const FString& InToken, bool bSeedStore, FManagerCallback CompletionCallback);
+UGameFuseCore::GetGameId();
+UGameFuseCore::GetGameName();
+UGameFuseCore::GetGameDescription();
+UGameFuseCore::GetGameToken();
+UGameFuseCore::GetBaseURL();
+UGameFuseCore::GetGameVariables();
+UGameFuseCore::GetGameStoreItems();
+UGameFuseCore::GetLeaderboard();
+UGameFuseCore::(const FString& Email, FManagerCallback CompletionCallback);
+UGameFuseCore::FetchGameVariables(FManagerCallback CompletionCallback);
+UGameFuseCore::FetchLeaderboardEntries(UGameFuseUser* GameFuseUser, const int Limit, bool bOnePerUser, const FString& LeaderboardName, FManagerCallback CompletionCallback);
+UGameFuseCore::FetchStoreItems(FManagerCallback CompletionCallback);
 ```
 
 ## User functions
@@ -73,7 +73,7 @@ StoreItems->GetIconUrl();
 ## Leaderboard
 
 ```cpp title="GameFuseLeaderboardEntry.h"
-TArray < UGameFuseLeaderboardEntry* > Leaderboards = UGameFuseManager::GetLeaderboard();
+TArray < UGameFuseLeaderboardEntry* > Leaderboards = UGameFuseCore::GetLeaderboard();
 
 Leaderboards->GetUsername();
 Leaderboards->GetScore();

--- a/docs/C++ Unreal Engine/custom user data.md
+++ b/docs/C++ Unreal Engine/custom user data.md
@@ -20,7 +20,7 @@ you must then convert the saved string into an array.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnAttributesFetchedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->FetchAttributes(false, CompletionCallback);
     }
 
@@ -31,7 +31,7 @@ you must then convert the saved string into an array.
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+            UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
             TMap Attributes = GameFuseUser->GetAttributes();
 
         }
@@ -47,7 +47,7 @@ you must then convert the saved string into an array.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnAttributesFetchedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->SetAttribute("CURRENT_LEVEL", "5", CompletionCallback);
     }
 

--- a/docs/C++ Unreal Engine/forgot password.md
+++ b/docs/C++ Unreal Engine/forgot password.md
@@ -18,7 +18,7 @@ they can login into your app.
         FManagerCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnMyLeaderboardsClearedCallback);
 
-        UGameFuseManager::SendPasswordResetEmail("example@gmail.com", CompletionCallback);
+        UGameFuseCore::SendPasswordResetEmail("example@gmail.com", CompletionCallback);
     }
 
     void UMyObject::OnResetUserPasswordCallback(bool bSuccess, const FString& Response)

--- a/docs/C++ Unreal Engine/game connection and variables.md
+++ b/docs/C++ Unreal Engine/game connection and variables.md
@@ -10,7 +10,7 @@ it is invoked when your game begins.
 To import the GameFuse library, add this at the beginning of any script:
 
 ```cpp
-#include "GameFuseManager.h"
+#include "GameFuseCore.h"
 ```
 
 Inside any script, on your first scene, you can run:
@@ -26,7 +26,7 @@ Inside any script, on your first scene, you can run:
         FManagerCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &AMyGameModeBase::GameSetUpCallback);
 
-        UGameFuseManager::SetUpGame(GameId, Token, bSeedStore, CompletionCallback);
+        UGameFuseCore::SetUpGame(GameId, Token, bSeedStore, CompletionCallback);
     }
 
     void AMyGameModeBase::GameSetUpCallback(bool bSuccess, const FString& Response)
@@ -46,7 +46,7 @@ Inside any script, on your first scene, you can run:
 
 ### Function return values
 
-#### `UGameFuseManager::SetUpGame`
+#### `UGameFuseCore::SetUpGame`
 
 | HTTP status code | Description |
 |------------------|-------------|
@@ -66,7 +66,7 @@ game, but you can also re-fetch them whenever you like.
         FManagerCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::VariablesFetchedCallback);
 
-        UGameFuseManager::FetchGameVariables(CompletionCallback);
+        UGameFuseCore::FetchGameVariables(CompletionCallback);
     }
 
     void UMyObject::VariablesFetchedCallback(bool bSuccess, const FString& Response)
@@ -76,7 +76,7 @@ game, but you can also re-fetch them whenever you like.
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            TMap < FString, FString > OurVariables = UGameFuseManager::GetGameVariables();
+            TMap < FString, FString > OurVariables = UGameFuseCore::GetGameVariables();
         }
         else
         {
@@ -88,7 +88,7 @@ game, but you can also re-fetch them whenever you like.
 
 ### Function return values
 
-#### `UGameFuseManager::FetchGameVariables`
+#### `UGameFuseCore::FetchGameVariables`
 
 | HTTP status code | Description |
 |------------------|-------------|

--- a/docs/C++ Unreal Engine/in game leaderboard.md
+++ b/docs/C++ Unreal Engine/in game leaderboard.md
@@ -82,7 +82,7 @@ for the game, and for the current user.
 
         UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 
-        UGameFuseManager::FetchLeaderboardEntries(GameFuseUser, 15, false, "leaderboard_name", CompletionCallback);
+        UGameFuseCore::FetchLeaderboardEntries(GameFuseUser, 15, false, "leaderboard_name", CompletionCallback);
     }
 
     void UMyObject::OnLeaderboardsFetchedCallback(bool bSuccess, const FString& Response)
@@ -92,7 +92,7 @@ for the game, and for the current user.
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            TArray < UGameFuseLeaderboardEntry* > Leaderboards = UGameFuseManager::GetLeaderboard();
+            TArray < UGameFuseLeaderboardEntry* > Leaderboards = UGameFuseCore::GetLeaderboard();
         }
         else
         {
@@ -142,7 +142,7 @@ current user like this:
 | `401`            | Can only add entries for current user |
 | `500`            | Unknown server error |
 
-### `UGameFuseManager::GetLeaderboard`
+### `UGameFuseCore::GetLeaderboard`
 
 | HTTP status code | Description |
 |------------------|-------------|
@@ -158,7 +158,7 @@ current user like this:
 | `401`            | Can only clear entries for the current user |
 | `500`            | Unknown server error |
 
-### `UGameFuseManager::GetLeaderboard`
+### `UGameFuseCore::GetLeaderboard`
 
 | HTTP status code | Description |
 |------------------|-------------|

--- a/docs/C++ Unreal Engine/in game leaderboard.md
+++ b/docs/C++ Unreal Engine/in game leaderboard.md
@@ -21,7 +21,7 @@ for the game, and for the current user.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnAttributesFetchedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 
         TMap < FString, FString > ExtraAttributes;
         ExtraAttributes.Add("deaths","15");
@@ -53,7 +53,7 @@ for the game, and for the current user.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnMyLeaderboardsFetchedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->FetchMyLeaderboardEntries(12, false, CompletionCallback);
     }
 
@@ -64,7 +64,7 @@ for the game, and for the current user.
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+            UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
             TArray < UGameFuseLeaderboardEntry* > MyLeaderboards = GameFuseUser->GetLeaderboards();
 
         }
@@ -80,7 +80,7 @@ for the game, and for the current user.
         FManagerCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnLeaderboardsFetchedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 
         UGameFuseManager::FetchLeaderboardEntries(GameFuseUser, 15, false, "leaderboard_name", CompletionCallback);
     }
@@ -112,7 +112,7 @@ current user like this:
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnMyLeaderboardsClearedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->ClearLeaderboardEntry("leaderboard_name", CompletionCallback);
     }
 

--- a/docs/C++ Unreal Engine/signing game users in.md
+++ b/docs/C++ Unreal Engine/signing game users in.md
@@ -12,7 +12,7 @@ sign in.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::SignedInCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->SignIn(Email, Password, CompletionCallback);
     }
 

--- a/docs/C++ Unreal Engine/signing game users up.md
+++ b/docs/C++ Unreal Engine/signing game users up.md
@@ -11,7 +11,7 @@ devices, since the data is saved online.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::SignedUpCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->SignUp(Email, Password, PasswordConfirmation, Username, CompletionCallback);
     }
 
@@ -34,7 +34,7 @@ To access the game user object form anywhere in the code, you can use the
 subsystem:
 
 ```cpp
-UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem < UGameFuseUser > ();
+UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 ```
 
 ## Function return values

--- a/docs/C++ Unreal Engine/using credits.md
+++ b/docs/C++ Unreal Engine/using credits.md
@@ -27,10 +27,10 @@ Finally you can run the *purchase store item* function successfully.
         CompletionCallback.BindDynamic(this, &UMyObject::OnCreditAddedCallback);
 
         UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
-        TArray <UGameFuseStoreItem*> StoreItems = UGameFuseManager::GetGameStoreItems();
+        TArray <UGameFuseStoreItem*> StoreItems = UGameFuseCore::GetGameStoreItems();
 
         UE_LOG(LogTemp, Error, TEXT("current credits : %d"), GameFuseUser->GetCredits());
-        UE_LOG(LogTemp, Error, TEXT("first store item price : %d"), (UGameFuseManager::GetGameStoreItems().Top()->GetCost()));
+        UE_LOG(LogTemp, Error, TEXT("first store item price : %d"), (UGameFuseCore::GetGameStoreItems().Top()->GetCost()));
 
         GameFuseUser->AddCredits(50, CompletionCallback);
     }
@@ -46,7 +46,7 @@ Finally you can run the *purchase store item* function successfully.
             CompletionCallback.BindDynamic(this, &UMyObject::OnPurchaseStoreItemCallback);
 
             UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
-            GameFuseUser->PurchaseStoreItem(UGameFuseManager::GetGameStoreItems().Top(), CompletionCallback);
+            GameFuseUser->PurchaseStoreItem(UGameFuseCore::GetGameStoreItems().Top(), CompletionCallback);
         }
         else
         {

--- a/docs/C++ Unreal Engine/using credits.md
+++ b/docs/C++ Unreal Engine/using credits.md
@@ -26,8 +26,8 @@ Finally you can run the *purchase store item* function successfully.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnCreditAddedCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
-        TArray < UGameFuseStoreItem* > StoreItems = UGameFuseManager::GetGameStoreItems();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
+        TArray <UGameFuseStoreItem*> StoreItems = UGameFuseManager::GetGameStoreItems();
 
         UE_LOG(LogTemp, Error, TEXT("current credits : %d"), GameFuseUser->GetCredits());
         UE_LOG(LogTemp, Error, TEXT("first store item price : %d"), (UGameFuseManager::GetGameStoreItems().Top()->GetCost()));
@@ -45,7 +45,7 @@ Finally you can run the *purchase store item* function successfully.
             FUserCallback CompletionCallback;
             CompletionCallback.BindDynamic(this, &UMyObject::OnPurchaseStoreItemCallback);
 
-            UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+            UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
             GameFuseUser->PurchaseStoreItem(UGameFuseManager::GetGameStoreItems().Top(), CompletionCallback);
         }
         else

--- a/docs/C++ Unreal Engine/using the store in your game.md
+++ b/docs/C++ Unreal Engine/using the store in your game.md
@@ -10,7 +10,7 @@ be refreshed every time you call 'FetchGameVariables()' again. To access store i
         FManagerCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::SignedInCallback);
 
-        UGameFuseManager::FetchGameVariables(CompletionCallback);
+        UGameFuseCore::FetchGameVariables(CompletionCallback);
     }
 
     void UMyObject::OnStoreItemsFetchedCallback(bool bSuccess, const FString& Response)
@@ -20,7 +20,7 @@ be refreshed every time you call 'FetchGameVariables()' again. To access store i
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            TArray< UGameFuseStoreItem* > StoreItems = UGameFuseManager::GetGameStoreItems();
+            TArray< UGameFuseStoreItem* > StoreItems = UGameFuseCore::GetGameStoreItems();
 
             for (UGameFuseStoreItem* StoreItem : StoreItems)
             {

--- a/docs/C++ Unreal Engine/using the store in your game.md
+++ b/docs/C++ Unreal Engine/using the store in your game.md
@@ -55,7 +55,7 @@ you are not signed in already.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnFetchUserPurchasedStoreItemsCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
         GameFuseUser->FetchPurchaseStoreItems(false, CompletionCallback);
     }
 
@@ -66,7 +66,7 @@ you are not signed in already.
             UE_LOG(LogTemp, Display, TEXT("Game Connected Successfully"));
             UE_LOG(LogTemp, Display, TEXT("Result : %s"), *Response);
 
-            UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+            UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
             TArray < UGameFuseStoreItem* > StoreItems = GameFuseUser->GetPurchasedStoreItems();
         }
         else
@@ -90,7 +90,7 @@ with the new item.
         FUserCallback CompletionCallback;
         CompletionCallback.BindDynamic(this, &UMyObject::OnFetchUserPurchasedStoreItemsCallback);
 
-        UGameFuseUser* GameFuseUser = GEtgaMeinstance()->getsubsysTEm < uGameFuseuser > ();
+        UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser> ();
 
         GameFuseUser->PurchaseStoreItem(StoreItem, CompletionCallback);
 


### PR DESCRIPTION
Fixes some syntax issues with GameFuseUser example lines.
Remove references to non existent GameFuseManager class, replaces with GameFuseCore.h